### PR TITLE
Added phpstan and bumped min versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ php:
   - 7.1
   - 7.2
 
+before_script:
+  # Install Imagick
+  - pear config-set preferred_state beta
+  - printf "\n" | pecl install imagick
+
 matrix:
   fast_finish: true
   include:
@@ -21,5 +26,4 @@ install:
   - travis_retry composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
 
 script:
-  - composer cs-check
   - composer test

--- a/composer.json
+++ b/composer.json
@@ -11,25 +11,28 @@
   ],
   "require": {
     "php": "~7.1",
-    "liip/functional-test-bundle": "^1.6",
+    "liip/functional-test-bundle": "^1.9",
     "doctrine/orm": "^2.5",
     "doctrine/data-fixtures": "^1.2",
-    "symfony/console": "^3.0|^4.0",
     "phpunit/phpunit": "^7.0",
-    "coduo/php-matcher": "^3.0",
-    "mikey179/vfsStream": "^1.3"
+    "coduo/php-matcher": "^3.1"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
+    "symfony/console": "^3.4|^4.0",
+    "symfony/security-acl": "^2.8|^3.0",
+    "symfony/framework-bundle": "^3.4",
+    "mikey179/vfsStream": "^1.6",
     "squizlabs/php_codesniffer": "^3.3",
     "doctrine/coding-standard": "^4.0",
-    "symfony/framework-bundle": "^3.3"
-  },
-  "conflict": {
-    "liip/functional-test-bundle": "1.7.1"
+    "phpstan/phpstan": "^0.10",
+    "phpstan/phpstan-phpunit": "^0.10",
+    "phpstan/phpstan-strict-rules": "^0.10"
   },
   "suggest": {
-    "ext-imagick": "To assert images and create fixture images"
+    "ext-imagick": "To assert images and create fixture images",
+    "symfony/console": "To use command line tool to generate tests stubs",
+    "mikey179/vfsStream": "To mock uploading large files"
   },
   "autoload": {
     "psr-4": {
@@ -45,8 +48,10 @@
     "cs-check": "vendor/bin/phpcs -p",
     "cs-fix": "vendor/bin/phpcbf -p",
     "phpunit": "vendor/bin/phpunit",
+    "analyse": "phpstan analyse --configuration=phpstan.neon src/ tests/ --level 5",
     "test": [
       "@cs-check",
+      "@analyse",
       "@phpunit"
     ]
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,12 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+parameters:
+    polluteScopeWithLoopInitialAssignments: true
+    ignoreErrors:
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
+        - '#Call to method Imagick::newimage\(\) with incorrect case: newImage#'
+        - '#Call to method Imagick::setimageformat\(\) with incorrect case: setImageFormat#'
+        - '#Call to method Imagick::getimageblob\(\) with incorrect case: getImageBlob#'
+        - '#Call to method Imagick::readimageblob\(\) with incorrect case: readImageBlob#'
+        - '#Call to method Imagick::compareimages\(\) with incorrect case: compareImages#'

--- a/src/Command/TestStubCreateCommand.php
+++ b/src/Command/TestStubCreateCommand.php
@@ -47,16 +47,13 @@ class TestStubCreateCommand extends ContainerAwareCommand
             );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : void
     {
         $directory = $this->getTestDirectoryPath($input->getArgument('path'));
         $namespace = $this->getNamespace($directory);
         $name      = $input->getArgument('name');
 
-        $customLoader = $input->getOption('custom-loader');
+        $customLoader = (bool) $input->getOption('custom-loader');
 
         $fileSystem = new Filesystem();
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,9 +10,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigTreeBuilder() : TreeBuilder
     {
         $treeBuilder = new TreeBuilder();

--- a/src/Listener/RestRequestFailTestExpectedOutputFileUpdater.php
+++ b/src/Listener/RestRequestFailTestExpectedOutputFileUpdater.php
@@ -59,9 +59,6 @@ final class RestRequestFailTestExpectedOutputFileUpdater implements TestListener
         $this->matcherPatterns = $matcherPatterns;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addFailure(Test $test, AssertionFailedError $e, float $time) : void
     {
         if (! $e instanceof ExpectationFailedException || $e->getComparisonFailure() === null) {
@@ -193,7 +190,7 @@ final class RestRequestFailTestExpectedOutputFileUpdater implements TestListener
                 }
 
                 $keys[] = $key;
-                if (empty($value)) {
+                if ($value === []) {
                     $value = $this->getOriginalEmptyJsonValue($originalExpected, $keys);
                 } else {
                     $value = $this->parseExpectedData($value, $keys, $originalExpected);
@@ -219,7 +216,7 @@ final class RestRequestFailTestExpectedOutputFileUpdater implements TestListener
 
         $key = \array_shift($keys);
         if (isset($originalExpected->{$key})) {
-            if (\count($keys)) {
+            if (\count($keys) > 0) {
                 return $this->getOriginalEmptyJsonValue($originalExpected->{$key}, $keys);
             }
             return $originalExpected->{$key};

--- a/src/Test/Loader/AbstractLoader.php
+++ b/src/Test/Loader/AbstractLoader.php
@@ -9,6 +9,8 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
 
 /**
  * Abstract fixture loader.
@@ -72,11 +74,12 @@ abstract class AbstractLoader extends AbstractFixture implements ContainerAwareI
     {
         $this->manager->flush();
 
-        $objectIdentity = $this
-            ->container
-            ->get('security.acl.object_identity_retrieval_strategy')
-            ->getObjectIdentity($resource);
-        $aclProvider    = $this->container->get('security.acl.provider');
+        /** @var ObjectIdentityRetrievalStrategyInterface $objectIdentityRetrievalStrategy */
+        $objectIdentityRetrievalStrategy = $this->container->get('security.acl.object_identity_retrieval_strategy');
+
+        $objectIdentity = $objectIdentityRetrievalStrategy->getObjectIdentity($resource);
+        /** @var MutableAclProviderInterface $aclProvider */
+        $aclProvider = $this->container->get('security.acl.provider');
         $aclProvider->deleteAcl($objectIdentity);
 
         $this->manager->flush();

--- a/src/Test/RestControllerWebTestCase.php
+++ b/src/Test/RestControllerWebTestCase.php
@@ -45,19 +45,13 @@ abstract class RestControllerWebTestCase extends WebTestCase
      */
     protected static $authTokens = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         static::$authentication = self::AUTHENTICATION_NONE;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         static::$authentication = self::AUTHENTICATION_NONE;
@@ -250,13 +244,6 @@ abstract class RestControllerWebTestCase extends WebTestCase
         return $client;
     }
 
-    /**
-     * Assert a request response.
-     *
-     * @param Response $response              The response.
-     * @param int      $expectedStatusCode    The expected HTTP response code.
-     * @param string   $expectedOutputContent The expected output.
-     */
     protected function assertRequestResponse(
         Response $response,
         int $expectedStatusCode,

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -30,7 +30,7 @@ abstract class WebTestCase extends LiipWebTestCase
     /**
      * Array with the number of assertions against expected files per test.
      *
-     * @var string[]
+     * @var array<string,int>
      */
     private $assertionExpectedFiles = [];
 
@@ -66,10 +66,7 @@ abstract class WebTestCase extends LiipWebTestCase
         return $client;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -83,15 +80,12 @@ abstract class WebTestCase extends LiipWebTestCase
         self::$mockedServices = [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
+    protected function tearDown() : void
     {
-        $container = $this->getContainer();
-
+        /** @var \Doctrine\Common\Persistence\ConnectionRegistry $doctrine */
+        $doctrine = $this->getContainer()->get('doctrine');
         /** @var Connection[] $connections */
-        $connections = $container->get('doctrine')->getConnections();
+        $connections = $doctrine->getConnections();
         foreach ($connections as $connection) {
             $connection->close();
         }
@@ -169,7 +163,7 @@ abstract class WebTestCase extends LiipWebTestCase
 
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropDatabase();
-        if (empty($metaData)) {
+        if ($metaData === []) {
             return;
         }
 
@@ -178,7 +172,10 @@ abstract class WebTestCase extends LiipWebTestCase
 
     protected function getObjectManager() : ObjectManager
     {
-        return $this->getContainer()->get('doctrine')->getManager();
+        /** @var \Doctrine\Common\Persistence\ManagerRegistry $doctrine */
+        $doctrine = $this->getContainer()->get('doctrine');
+
+        return $doctrine->getManager();
     }
 
     protected static function getMatcher() : Matcher

--- a/tests/Listener/RestRequestFailTestExpectedOutputFileUpdaterTest.php
+++ b/tests/Listener/RestRequestFailTestExpectedOutputFileUpdaterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Speicher210\FunctionalTestBundle\Tests;
+namespace Speicher210\FunctionalTestBundle\Tests\Listener;
 
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\ExpectationFailedException;


### PR DESCRIPTION
Version bumping should have probably been done in a separate PR, but it was more convenient to do it now.
Some dependencies that are not always mandatory have been moved to suggest.
Some dependencies have been bumped to their LTS or fixed minimum version.

Return types have been added so this means BC breaks.

PHPStan is on level 5