### PR TITLE
Added option to pass query params as array for assertRestGetPath method

### DIFF
--- a/src/Test/RestControllerWebTestCase.php
+++ b/src/Test/RestControllerWebTestCase.php
@@ -103,18 +103,22 @@ abstract class RestControllerWebTestCase extends WebTestCase
      * Shorthand method for assertRestRequest() with a GET request.
      *
      * @param string  $path               The API path to test.
+     * @param mixed[] $queryParams        The query parameters.
      * @param int     $expectedStatusCode The expected HTTP response code.
      * @param mixed[] $server             The server parameters.
      */
     protected function assertRestGetPath(
         string $path,
+        array $queryParams = [],
         int $expectedStatusCode = Response::HTTP_OK,
         array $server = []
     ) : Client {
+        \parse_str(\parse_url($path, \PHP_URL_QUERY) ?? '', $queryParamsFromPath);
+
         $request = Request::create(
             $path,
             Request::METHOD_GET,
-            [],
+            \array_replace_recursive($queryParamsFromPath, $queryParams),
             [],
             [],
             $server

--- a/tests/Test/RestControllerWebTestCaseTest.php
+++ b/tests/Test/RestControllerWebTestCaseTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Speicher210\FunctionalTestBundle\Tests\Test;
+
+use PHPUnit\Framework\TestCase;
+use Speicher210\FunctionalTestBundle\Test\RestControllerWebTestCase;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RestControllerWebTestCaseTest extends TestCase
+{
+    /**
+     * @return mixed[]
+     */
+    public static function dataProviderTestAssertRestGetPathWithCustomQueryParams() : array
+    {
+        return [
+            ['/test/path', [], '/test/path', null],
+            ['/test/path?param=1', [], '/test/path', 'param=1'],
+            ['/test/path', ['param' => '1'], '/test/path', 'param=1'],
+            ['/test/path?param=1', ['param' => 'override'], '/test/path', 'param=override'],
+            ['/test/path?param=1', ['param2' => '2'], '/test/path', 'param=1&param2=2'],
+            [
+                '/test/path?a[b][c]=1&a[b][d]=2',
+                [
+                    'a' => [
+                        'b' => ['d' => '3'],
+                    ],
+                ],
+                '/test/path',
+                'a[b][c]=1&a[b][d]=3',
+            ],
+            [
+                '/test/path?a[b][c]=1&a[b][d]=2',
+                [
+                    'a' => [
+                        'b' => ['d' => '3'],
+                        'e' => '5',
+                    ],
+                    'f' => '4',
+                ],
+                '/test/path',
+                'a[b][c]=1&a[b][d]=3&a[e]=5&f=4',
+            ],
+            [
+                '/test/path?a[b][c]=1&a[b][d]=2&a[e]=5&f=4',
+                [
+                    'a' => [
+                        'b' => ['d' => '3'],
+                    ],
+                ],
+                '/test/path',
+                'a[b][c]=1&a[b][d]=3&a[e]=5&f=4',
+            ],
+        ];
+    }
+
+    /**
+     * @param mixed[] $queryParams
+     *
+     * @dataProvider dataProviderTestAssertRestGetPathWithCustomQueryParams
+     */
+    public function testAssertRestGetPathWithCustomQueryParams(
+        string $path,
+        array $queryParams,
+        string $expectedPathInfo,
+        ?string $expectedQueryString
+    ) : void {
+        $testClass = new class() extends RestControllerWebTestCase
+        {
+            /**
+             * @param mixed[] $queryParams
+             */
+            public function testAssertRestGetPath(string $path, array $queryParams = []) : Client
+            {
+                return parent::assertRestGetPath($path, $queryParams);
+            }
+
+            protected function assertRestRequest(Request $request, int $expectedStatusCode = Response::HTTP_OK) : Client
+            {
+                $client = $this->createMock(Client::class);
+                $client->method('getRequest')->willReturn($request);
+
+                return $client;
+            }
+        };
+
+        /** @var Client $client */
+        $client = $testClass->testAssertRestGetPath($path, $queryParams);
+        self::assertSame($expectedPathInfo, $client->getRequest()->getPathInfo());
+        $requestQueryString = $client->getRequest()->getQueryString();
+        self::assertSame(
+            $expectedQueryString,
+            $requestQueryString !== null ? \urldecode($requestQueryString) : null
+        );
+    }
+}


### PR DESCRIPTION
PR for change proposed in here: https://github.com/Speicher210/FunctionalTestBundle/issues/10#issuecomment-416603353